### PR TITLE
Use str rather than basestring for python3 compat

### DIFF
--- a/flowdock/streaming.py
+++ b/flowdock/streaming.py
@@ -43,7 +43,7 @@ class StreamingAPI(object):
 		return self.connection
 
 	def fetch(self, flows, active=None, plain=False):
-		assert isinstance(flows, (list, basestring)), 'The `flows` argument must be string or list instance.'
+		assert isinstance(flows, (list, str)), 'The `flows` argument must be string or list instance.'
 		assert active in self.ALLOWED_STATUSES, 'The `active` argument must be in %s.' % str(self.ALLOWED_STATUSES)
 		self.flows = flows
 		self.active = active


### PR DESCRIPTION
I could do this with six if you want as well (for both py2/3). Lemme know! :smiley: